### PR TITLE
Feature: Refactor Protocol-Parse

### DIFF
--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -129,16 +129,13 @@ export class Base implements InterfaceBase {
     });
     this.socket.on("data", (data) => {
       this.protocol.write(data);
-      while (true) {
-        this.protocol.parse();
-        if (!this.protocol.data.state) {
-          break;
-        }
+      const parsed = this.protocol.parse();
+      parsed.forEach((message) => {
         (this.callbacks.shift() as callback)(
-          this.protocol.data.res.error,
-          this.protocol.data.res.data
+          false,
+          message
         );
-      }
+      });
     });
   }
 }

--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -1,8 +1,9 @@
+import { Http2ServerResponse } from "http2";
 import { createConnection, Socket } from "net";
 import { connect, TLSSocket } from "tls";
 import { v4 as uuidv4 } from "uuid";
 // core
-import { Protocol } from "./protocol";
+import { Protocol, RedisProtocolError } from "./protocol";
 
 type callback = (err: boolean, res: any) => void;
 
@@ -96,7 +97,9 @@ export class Base implements InterfaceBase {
   }
   private async auth(password: string) {
     try {
-      return await this.command("AUTH", password);
+      const authResponse = await this.command("AUTH", password);
+      if (authResponse instanceof Error) { throw authResponse; }
+      return authResponse;
     } catch (error) {
       this.socket.emit("error", error);
       this.socket.end();

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -1,5 +1,13 @@
 import { Base } from "./base";
 
+const respStart = "(?<=\\r\\n|^)";
+const respEnd = "(?=\\r\\n)";
+
+interface InterfaceParser {
+  matches: RegExpMatchArray[];
+  blobs: Map<string, string>;
+}
+
 export class Protocol {
   private _buffer: string;
   constructor() {
@@ -46,30 +54,66 @@ export class RedisProtocolError extends Error {
 }
 
 class ProtocolParser {
-  public static parse(raw: string): any[] {
+  public static parse(raw: string): InterfaceParser {
     let masterRegex = [
       "\\+(?<simple>.+?)",
       "\\-(?<error>.+?)",
       "\\:(?<int>-?\\d+)",
-      "\\$(?<bulk_n>\\d+)\\r\\n(?<bulk>.*?)",
+      "(?<blobString>\\$blobRef_\\d+)", // Note: this matches our replaced Blob-Ref
       "\\*(?<array_n>\\d+)(?<array>)",
       "(\\$|\\*)(?<null_string>-1)",
     ].join("|");
 
-    masterRegex = `(?<=\\r\\n|^)(?:${masterRegex})(?=\\r\\n)`;
-    return Array.from(raw.matchAll(new RegExp(masterRegex, "g")));
+    // Preprocess blobs since they can include <CR><LF>
+    const blobs = ProtocolParser.extractBlobs(raw, "$");
+
+    masterRegex = `${respStart}(?:${masterRegex})${respEnd}`;
+    const matches = Array.from(blobs.buffer.matchAll(new RegExp(masterRegex, "g")));
+    return {
+      matches,
+      blobs: blobs.output,
+    };
   }
-  public static collect(parsed: any[]): any[] {
+  public static collect(parsed: InterfaceParser): any[] {
     const output = new Array();
     do {
       ProtocolParser.aggregateMessages(parsed, output);
-    } while (parsed.length > 0);
+    } while (parsed.matches.length > 0);
 
     return output;
   }
-  private static aggregateMessages(parsed: any[], output: any[]) {
-    const current = parsed.shift();
-    if (current !== undefined) {
+  private static extractBlobs(
+    raw: string,
+    blobByte: string,
+    blobs: Map<string, string>= new Map()
+  ): {output: Map<string, string>, buffer: string} {
+    let buffer = raw;
+    let refInx = 0;
+    // This expression matches all `\r\n$N\r\n` where `N` is digit(s) to find all blob specifications
+    const blobSizeRegex = `${respStart}\\${blobByte}(?<byteCount>\\d+)${respEnd}`;
+    const blobMatches = Array.from(buffer.matchAll(new RegExp(blobSizeRegex, "g")));
+    for (const blob of blobMatches) {
+      if (blob.groups !== undefined) {
+        // this expression looks for something like `$N\r\n1..N\r\n` (where N = byteCount characters to match)
+        const fullBlobRegex = `${respStart}\\${blobByte}(?<byteCount>${blob.groups.byteCount})\\r\\n` +
+                              `(?<blob>.{${blob.groups.byteCount}})${respEnd}`;
+        const blobMatch = buffer.match(new RegExp(fullBlobRegex, "s"));
+        if (blobMatch !== null && blobMatch.groups !== undefined) {
+          const key = `${blobByte}blobRef_${refInx}`;
+          refInx++;
+          blobs.set(key, blobMatch.groups.blob);
+          buffer = buffer.replace(new RegExp(fullBlobRegex, "s"), key);
+        }
+      }
+    }
+    return {
+      output: blobs,
+      buffer,
+    };
+  }
+  private static aggregateMessages(parsed: InterfaceParser, output: any[]) {
+    const current = parsed.matches.shift();
+    if (current !== undefined && current.groups !== undefined) {
       if ("array_n" in current.groups && current.groups.array_n !== undefined) {
         const array_n = parseInt(current.groups.array_n, 10);
         const arrayResp = new Array();
@@ -80,12 +124,8 @@ class ProtocolParser {
         if (arrayResp.length === array_n) {
           output.push(arrayResp);
         }
-      } else if ("bulk" in current.groups && current.groups.bulk !== undefined) {
-        const strLength = parseInt(current.groups.bulk_n, 10);
-        const bulkString = Buffer.from(current.groups.bulk).slice(0, strLength);
-        if (bulkString.length === strLength) {
-          output.push(bulkString.toString());
-        }
+      } else if ("blobString" in current.groups && current.groups.blobString !== undefined) {
+        output.push(parsed.blobs.get(current.groups.blobString));
       } else if ("null_string" in current.groups && current.groups.null_string !== undefined) {
         output.push(null);
       } else if ("error" in current.groups && current.groups.error !== undefined) {

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -34,7 +34,6 @@ export class Protocol {
 }
 
 export class RedisProtocolError extends Error {
-
   public static fromMessage(message: string) {
     const space = message.indexOf(" ");
     return new RedisProtocolError(message.slice(0, space), message.slice(space + 1));
@@ -60,13 +59,6 @@ class ProtocolParser {
     masterRegex = `(?<=\\r\\n|^)(?:${masterRegex})(?=\\r\\n)`;
     return Array.from(raw.matchAll(new RegExp(masterRegex, "g")));
   }
-
-  /**
-   * Collect message arrays and bulk strings and convert messages to their correct types
-   * @param parsed - array of parsed messages
-   *
-   * @return
-   */
   public static collect(parsed: any[]): any[] {
     const output = new Array();
     do {
@@ -75,12 +67,6 @@ class ProtocolParser {
 
     return output;
   }
-
-  /**
-   * Iterate over parsed response array collecting messages in output
-   * @param parsed - array of parsed messages
-   * @param output
-   */
   private static aggregateMessages(parsed: any[], output: any[]) {
     const current = parsed.shift();
     if (current !== undefined) {

--- a/test/core/protocol.spec.ts
+++ b/test/core/protocol.spec.ts
@@ -1,3 +1,4 @@
+import { DESTRUCTION } from "dns";
 import { Protocol } from "../../src/core/protocol";
 
 let protocol: Protocol;
@@ -13,83 +14,276 @@ beforeEach(async () => {
 });
 
 describe("parse", () => {
-  it(`+OK`, () => {
-    protocol.write(Buffer.from(`+OK\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: "OK",
-      },
+  // Tests based on specification https://redis.io/topics/protocol
+  describe("RESP Simple Strings", () => {
+    /**
+     * When Redis replies with a Simple String, a client library should return
+     * to the caller a string composed of the first character after the '+' up
+     * to the end of the string, excluding the final CRLF bytes.
+     */
+    it(`+OK`, () => {
+      protocol.write(Buffer.from(`+OK\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "OK",
+        },
+      });
+    });
+    it(`+Another Simple String`, () => {
+      protocol.write(Buffer.from(`+Another Simple String\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "Another Simple String",
+        },
+      });
     });
   });
-  it(`-Error type`, () => {
-    protocol.write(Buffer.from(`-Error type\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: true,
-        data: "Error type",
-      },
+
+  describe("RESP Errors", () => {
+    /**
+     * ... errors are treated by clients as exceptions, and the string that
+     * composes the Error type is the error message itself.
+     *
+     * The first word after the "-", up to the first space or newline,
+     * represents the kind of error returned.
+     */
+    it(`-Error message`, () => {
+      protocol.write(Buffer.from(`-Error message\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: true,
+          data: "Error message",
+        },
+      });
+    });
+    it(`-ERR unknown command 'foobar'`, () => {
+      protocol.write(Buffer.from(`-ERR unknown command 'foobar'\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: true,
+          data: "ERR unknown command 'foobar'",
+        },
+      });
+    });
+    it(`-WRONGTYPE Operation against a key holding the wrong kind of value`, () => {
+      protocol.write(Buffer.from(`-WRONGTYPE Operation against a key holding the wrong kind of value\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: true,
+          data: "WRONGTYPE Operation against a key holding the wrong kind of value",
+        },
+      });
     });
   });
-  it(`:6`, () => {
-    protocol.write(Buffer.from(`:6\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: 6,
-      },
+
+  describe("RESP Integers", () => {
+    /**
+     * This type is just a CRLF terminated string representing an integer,
+     * prefixed by a ":" byte. For example ":0\r\n", or ":1000\r\n" are integer
+     * replies.
+     *
+     * ... the returned integer is guaranteed to be in the range of a signed 64
+     * bit integer.
+     */
+    it(`:0`, () => {
+      protocol.write(Buffer.from(`:0\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: 0,
+        },
+      });
+    });
+    it(`:1000`, () => {
+      protocol.write(Buffer.from(`:1000\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: 1000,
+        },
+      });
+    });
+    it(`:-1`, () => {
+      protocol.write(Buffer.from(`:-1\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: -1,
+        },
+      });
+    });
+    it(`:-2147483648`, () => {
+      protocol.write(Buffer.from(`:-2147483648\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: -2147483648,
+        },
+      });
+    });
+    it(`:2147483647`, () => {
+      protocol.write(Buffer.from(`:2147483647\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: 2147483647,
+        },
+      });
     });
   });
-  it(`* array`, () => {
-    protocol.write(
-      Buffer.from(`*3\r\n$1\r\n1\r\n$5\r\nhello\r\n$5\r\ntedis\r\n`)
-    );
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: ["1", "hello", "tedis"],
-      },
+
+  describe("RESP Bulk Strings", () => {
+    /**
+     * Bulk Strings are encoded in the following way:
+     *  - A "$" byte followed by the number of bytes composing the string
+     *    (a prefixed length), terminated by CRLF.
+     *  - The actual string data.
+     *  - A final CRLF.
+     *
+     * RESP Bulk Strings can also be used in order to signal non-existence of a
+     * value using a special format that is used to represent a Null value. In
+     * this special format the length is -1, and there is no data ... This is
+     * called a **Null Bulk String**. The client library API should not return
+     * an empty string, but a nil object, when the server replies with a Null
+     * Bulk String. For example a Ruby library should return 'nil' while a C
+     * library should return NULL (or set a special flag in the reply object),
+     * and so forth.
+     */
+    it(`$6 foobar`, () => {
+      protocol.write(Buffer.from(`$6\r\nfoobar\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "foobar",
+        },
+      });
+    });
+    it(`$0`, () => {
+      protocol.write(Buffer.from(`$0\r\n\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "",
+        },
+      });
+    });
+    it(`$-1`, () => {
+      protocol.write(Buffer.from(`$-1\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: null,
+        },
+      });
+    });
+    it(`$ array`, () => {
+      protocol.write(Buffer.from(`$9\r\nhello\r\nworld!\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: ["hello", "world!"],
+        },
+      });
+    });
+    it(`$ incomplete`, () => {
+      protocol.write(Buffer.from(`$3\r\nhello`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: false,
+        res: {
+          error: false,
+          data: null,
+        },
+      });
     });
   });
-  it(`$ array`, () => {
-    protocol.write(Buffer.from(`$9\r\nhello\r\nworld!\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: ["hello", "world!"],
-      },
+
+  describe("RESP Arrays", () => {
+    /**
+     * RESP Arrays are sent using the following format:
+     *  - A '*' character as the first byte, followed by the number of elements
+     *    in the array as a decimal number, followed by CRLF.
+     *  - An additional RESP type for every element of the Array.
+     */
+    it(`*0 Empty Array`, () => {
+      protocol.write(
+        Buffer.from(`*0\r\n`)
+      );
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: [],
+        },
+      });
     });
-  });
-  it(`* incomplete`, () => {
-    protocol.write(Buffer.from(`*3\r\n$1\r\nhello`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: false,
-      res: {
-        error: false,
-        data: [],
-      },
+    it(`*2 foo bar`, () => {
+      protocol.write(
+        Buffer.from(`*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n`)
+      );
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: ["foo", "bar"],
+        },
+      });
     });
-  });
-  it(`$ incomplete`, () => {
-    protocol.write(Buffer.from(`$3\r\nhello`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: false,
-      res: {
-        error: false,
-        data: null,
-      },
+    it(`* array`, () => {
+      protocol.write(
+        Buffer.from(`*3\r\n$1\r\n1\r\n$5\r\nhello\r\n$5\r\ntedis\r\n`)
+      );
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: ["1", "hello", "tedis"],
+        },
+      });
+    });
+    it(`* incomplete`, () => {
+      protocol.write(Buffer.from(`*3\r\n$1\r\nhello`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: false,
+        res: {
+          error: false,
+          data: [],
+        },
+      });
     });
   });
   it(`! type error`, () => {

--- a/test/core/protocol.spec.ts
+++ b/test/core/protocol.spec.ts
@@ -127,10 +127,10 @@ describe("parse", () => {
       data = protocol.parse();
       expect(data).toEqual([null]);
     });
-    it(`$ array`, () => {
-      protocol.write(Buffer.from(`$9\r\nhello world!\r\n`));
+    it(`$ includes CRLF`, () => {
+      protocol.write(Buffer.from(`$13\r\nhello\r\nworld!\r\n`));
       data = protocol.parse();
-      expect(data).toEqual(["hello wor"]);
+      expect(data).toEqual([`hello\r\nworld!`]);
     });
     it(`$ incomplete`, () => {
       protocol.write(Buffer.from(`$3\r\nhe`));
@@ -205,20 +205,6 @@ describe("parse", () => {
       expect(data).toEqual([]);
     });
   });
-  // it(`! type error`, () => {
-  //   protocol.write(Buffer.from(`!3\r\nhello\r\n`));
-  //   data = protocol.parse();
-  //   expect(data).toEqual({
-  //     state: false,
-  //     res: {
-  //       error: false,
-  //       data: [
-  //         new RedisProtocolError("UNRECOGNIZED RESP", "Failed to parse the line: '!3'."),
-  //         new RedisProtocolError("UNRECOGNIZED RESP", "Failed to parse the line: 'hello'."),
-  //       ],
-  //     },
-  //   });
-  // });
 });
 
 describe("encode", () => {

--- a/test/core/protocol.spec.ts
+++ b/test/core/protocol.spec.ts
@@ -117,7 +117,7 @@ describe("parse", () => {
       data = protocol.parse();
       expect(data).toEqual(["foobar"]);
     });
-    it(`$0`, () => {
+    it(`$0 Empty String`, () => {
       protocol.write(Buffer.from(`$0\r\n\r\n`));
       data = protocol.parse();
       expect(data).toEqual([""]);
@@ -137,6 +137,12 @@ describe("parse", () => {
       data = protocol.parse();
       expect(data).toEqual([]);
     });
+    it(`$ incomplete`, () => {
+      protocol.write(Buffer.from(`$9\r\n世界！\r\n`));
+      data = protocol.parse();
+      expect(data).toEqual(["世界！"]);
+    });
+
   });
 
   describe("RESP Arrays", () => {


### PR DESCRIPTION
I'm working on adding the Redis Module, RedisTimeSeries.  This module responds with arrays of mixed data types and the original Tedis protocol parser was not handling them properly.  I tried to take a stab at updating the protocol parser to be more flexible and robust.

Please let me know if you'd like to see any of this code factored a different way.  I tried to respect your coding style as much as possible.

Tedis rocks!