### PR TITLE
Feature/add redis timeseries module

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,14 @@ services:
     environment:
       REDIS_PASSWORD: tedis_love_you
     command: ["sh", "-c", 'exec redis-server --requirepass "$$REDIS_PASSWORD"']
+  redis-ts:
+    image: redislabs/redistimeseries
+    networks:
+      - net-redis
+    ports:
+      - "6371:6371"
+    volumes:
+      - volume-redis:/data
+    environment:
+      REDIS_PASSWORD: tedis_love_you
+    command: ["sh", "-c", 'exec redis-server --requirepass "$$REDIS_PASSWORD" --port 6371 --loadmodule /usr/lib/redis/modules/redistimeseries.so']

--- a/src/api/timeseries.ts
+++ b/src/api/timeseries.ts
@@ -5,6 +5,7 @@ enum MethodTimeseries {
   tscreate = "TS.CREATE",
   tsalter = "TS.ALTER",
   tsadd = "TS.ADD",
+  tsmadd = "TS.MADD",
   tsinfo = "TS.INFO",
 }
 
@@ -31,6 +32,12 @@ export interface InterfaceTimeseries {
       uncompressed?: boolean,
       labels?: {[propName: string]: string | number; }
     }): Promise<number>;
+  tsmadd(
+    data: Array<{
+      key: string,
+      timestamp?: number | "*" | undefined,
+      value: number | string
+    }>): Promise<number[]>;
   tsinfo(key: string): Promise<any>;
 }
 
@@ -80,6 +87,24 @@ export class RedisTimeseries extends Base implements InterfaceTimeseries {
     } else {
       return this.command(MethodTimeseries.tsadd, key, timestamp, value);
     }
+  }
+  public tsmadd(
+    data: Array<{
+      key: string,
+      timestamp?: number | "*" | undefined,
+      value: number | string
+    }>) {
+    const collected = new Array();
+    data.forEach((item) => {
+      collected.push(item.key);
+      if (item.timestamp === undefined) {
+        collected.push("*");
+      } else {
+        collected.push(item.timestamp);
+      }
+      collected.push(item.value);
+    });
+    return this.command(MethodTimeseries.tsmadd, ...collected);
   }
   public async tsinfo(key: string) {
     return this.command(MethodTimeseries.tsinfo, key).then((array) => {

--- a/src/api/timeseries.ts
+++ b/src/api/timeseries.ts
@@ -6,6 +6,9 @@ enum MethodTimeseries {
   tsalter = "TS.ALTER",
   tsadd = "TS.ADD",
   tsmadd = "TS.MADD",
+  tsincrby = "TS.INCRBY",
+  tsdecrby = "TS.DECRBY",
+  tsget = "TS.GET",
   tsinfo = "TS.INFO",
 }
 
@@ -38,6 +41,25 @@ export interface InterfaceTimeseries {
       timestamp?: number | "*" | undefined,
       value: number | string
     }>): Promise<number[]>;
+  tsincrby(
+    key: string,
+    value: number | string,
+    timestamp: number | "*" | undefined,
+    options?: {
+      retention?: number,
+      uncompressed?: boolean,
+      labels?: {[propName: string]: string | number; }
+    }): Promise<number>;
+  tsdecrby(
+    key: string,
+    value: number | string,
+    timestamp: number | "*" | undefined,
+    options?: {
+      retention?: number,
+      uncompressed?: boolean,
+      labels?: {[propName: string]: string | number; }
+    }): Promise<number>;
+  tsget(key: string): Promise<number | string>;
   tsinfo(key: string): Promise<any>;
 }
 
@@ -105,6 +127,47 @@ export class RedisTimeseries extends Base implements InterfaceTimeseries {
       collected.push(item.value);
     });
     return this.command(MethodTimeseries.tsmadd, ...collected);
+  }
+  public tsincrby(
+    key: string,
+    value: number | string,
+    timestamp: number | "*" | undefined,
+    options?: {
+      retention?: number,
+      uncompressed?: boolean,
+      labels?: {[propName: string]: string | number; }
+    }) {
+    if (timestamp === undefined) {
+      timestamp = "*";
+    }
+    if (options !== undefined) {
+      const collected = collectOptions(options);
+      return this.command(MethodTimeseries.tsincrby, key, value, "TIMESTAMP", timestamp, ...collected);
+    } else {
+      return this.command(MethodTimeseries.tsincrby, key, value, "TIMESTAMP", timestamp);
+    }
+  }
+  public tsdecrby(
+    key: string,
+    value: number | string,
+    timestamp: number | "*" | undefined,
+    options?: {
+      retention?: number,
+      uncompressed?: boolean,
+      labels?: {[propName: string]: string | number; }
+    }) {
+    if (timestamp === undefined) {
+      timestamp = "*";
+    }
+    if (options !== undefined) {
+      const collected = collectOptions(options);
+      return this.command(MethodTimeseries.tsdecrby, key, value, "TIMESTAMP", timestamp, ...collected);
+    } else {
+      return this.command(MethodTimeseries.tsdecrby, key, value, "TIMESTAMP", timestamp);
+    }
+  }
+  public tsget(key: string) {
+    return this.command(MethodTimeseries.tsget, key);
   }
   public async tsinfo(key: string) {
     return this.command(MethodTimeseries.tsinfo, key).then((array) => {

--- a/src/api/timeseries.ts
+++ b/src/api/timeseries.ts
@@ -1,0 +1,43 @@
+import { Base } from "../core/base";
+import { Array2Object } from "../util/tools";
+
+enum MethodTimeseries {
+  tscreate = "TS.CREATE",
+}
+
+export interface InterfaceTimeseries {
+  tscreate(
+    key: string,
+    options: {
+      retention?: number,
+      labels?: { [propName: string]: string | number; }
+    }): Promise<number>;
+}
+
+export class RedisTimeseries extends Base implements InterfaceTimeseries {
+  public tscreate(key: string, options: {retention?: number, labels?: {[propName: string]: string | number; }}) {
+    if (options !== undefined) {
+      const collected = collectOptions(options);
+      return this.command(MethodTimeseries.tscreate, key, ...collected);
+    } else {
+      return this.command(MethodTimeseries.tscreate, key);
+    }
+  }
+}
+
+function collectOptions(options: {retention?: number, labels?: {[propName: string]: string | number; }}) {
+  const collected = new Array();
+  if (options.retention !== undefined) {
+    collected.push("RETENTION", options.retention);
+  }
+
+  if (options.labels !== undefined) {
+    const labels = options.labels;
+    collected.push("LABELS");
+    (Reflect.ownKeys(options.labels) as string[]).forEach((field) => {
+      collected.push(field, labels[field]);
+    });
+  }
+
+  return collected;
+}

--- a/src/api/timeseries.ts
+++ b/src/api/timeseries.ts
@@ -3,25 +3,42 @@ import { Array2Object } from "../util/tools";
 
 enum MethodTimeseries {
   tscreate = "TS.CREATE",
+  tsinfo = "TS.INFO",
 }
 
 export interface InterfaceTimeseries {
   tscreate(
     key: string,
-    options: {
+    options?: {
       retention?: number,
       labels?: { [propName: string]: string | number; }
     }): Promise<number>;
+  tsinfo(key: string): Promise<any>;
 }
 
 export class RedisTimeseries extends Base implements InterfaceTimeseries {
-  public tscreate(key: string, options: {retention?: number, labels?: {[propName: string]: string | number; }}) {
+  public tscreate(key: string, options?: {retention?: number, labels?: {[propName: string]: string | number; }}) {
     if (options !== undefined) {
       const collected = collectOptions(options);
       return this.command(MethodTimeseries.tscreate, key, ...collected);
     } else {
       return this.command(MethodTimeseries.tscreate, key);
     }
+  }
+  public tsinfo(key: string) {
+    return this.command(MethodTimeseries.tsinfo, key).then((array) => {
+      const response = Array2Object(array);
+      if (response.labels !== undefined) {
+        // first flatten labels
+        // [[key, value], [key, value]] to [key value key value]
+        let temp: any[] = new Array();
+        response.labels.forEach((label: any[]) => {
+          temp = temp.concat(label);
+        });
+        response.labels = Array2Object(temp);
+      }
+      return response;
+    });
   }
 }
 

--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -129,16 +129,13 @@ export class Base implements InterfaceBase {
     });
     this.socket.on("data", (data) => {
       this.protocol.write(data);
-      while (true) {
-        this.protocol.parse();
-        if (!this.protocol.data.state) {
-          break;
-        }
+      const parsed = this.protocol.parse();
+      parsed.forEach((message) => {
         (this.callbacks.shift() as callback)(
-          this.protocol.data.res.error,
-          this.protocol.data.res.data
+          false,
+          message
         );
-      }
+      });
     });
   }
 }

--- a/src/core/tedis.ts
+++ b/src/core/tedis.ts
@@ -4,6 +4,7 @@ import { InterfaceKey, RedisKey } from "../api/key";
 import { InterfaceList, RedisList } from "../api/list";
 import { InterfaceSet, RedisSet } from "../api/set";
 import { InterfaceString, RedisString } from "../api/string";
+import { InterfaceTimeseries, RedisTimeseries } from "../api/timeseries";
 import { InterfaceZset, RedisZset } from "../api/zset";
 // util
 import { Mixins } from "../util/tools";
@@ -17,7 +18,8 @@ interface InterfaceRedis
     InterfaceHash,
     InterfaceList,
     InterfaceSet,
-    InterfaceZset {}
+    InterfaceZset,
+    InterfaceTimeseries {}
 
 export class Tedis extends Mixins<
   new (options?: {
@@ -30,4 +32,4 @@ export class Tedis extends Mixins<
       cert: Buffer;
     };
   }) => InterfaceRedis
->(Base, [RedisKey, RedisString, RedisHash, RedisList, RedisSet, RedisZset]) {}
+>(Base, [RedisKey, RedisString, RedisHash, RedisList, RedisSet, RedisZset, RedisTimeseries]) {}

--- a/src/util/tools.ts
+++ b/src/util/tools.ts
@@ -8,7 +8,7 @@ export function Mixins<T>(base: any, froms: any[]): T {
   return Mixin as any;
 }
 
-export function Array2Object(array: any[]): { [propName: string]: string } {
+export function Array2Object(array: any[]): { [propName: string]: any } {
   const obj: { [propName: string]: string } = {};
   for (let i = 0, len = array.length; i < len; i++) {
     obj[array[i]] = array[++i];

--- a/test/api/timeseries.spec.ts
+++ b/test/api/timeseries.spec.ts
@@ -21,7 +21,11 @@ afterAll(async () => {
 
 describe("Redis Timeseries Test: TS.CREATE", () => {
   it(`create key with all options`, async () => {
-    expect(await Timeseries.tscreate("temperature:2:32", {retention: 60000, labels: {sensor_id: 2, area_id: 32}})).toBe("OK");
+    expect(await Timeseries.tscreate("temperature:2:32", {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe("OK");
     const info = await Timeseries.tsinfo("temperature:2:32");
     expect(info.retentionTime).toBe(60000);
     expect(info.labels.sensor_id).toBe("2");
@@ -43,5 +47,93 @@ describe("Redis Timeseries Test: TS.CREATE", () => {
     const info = await Timeseries.tsinfo("temperature:5");
     expect(info.retentionTime).toBe(0);
     expect(info.labels.sensor_id).toBe("5");
+  });
+});
+
+describe("Redis Timeseries Test: TS.ALTER", () => {
+  it(`alter key with all options`, async () => {
+    expect(await Timeseries.tscreate("temperature:2:32", {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe("OK");
+    let info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe("2");
+    expect(await Timeseries.tsalter("temperature:2:32", {
+      retention: 30000,
+      labels: {sensor_id: 20, area_id: 34},
+    })).toBe("OK");
+    info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(30000);
+    expect(info.labels.sensor_id).toBe("20");
+  });
+  it(`alter key with no options`, async () => {
+    expect(await Timeseries.tscreate("temperature:2:32", {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe("OK");
+    let info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe("2");
+    expect(await Timeseries.tsalter("temperature:2:32")).toBe("OK");
+    info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe("2");
+  });
+  it(`alter key, deleting labels`, async () => {
+    expect(await Timeseries.tscreate("temperature:2:32", {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe("OK");
+    let info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.labels.sensor_id).toBe("2");
+    expect(await Timeseries.tsalter("temperature:2:32", {labels: {}})).toBe("OK");
+    info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe(undefined);
+  });
+});
+
+describe("Redis Timeseries Test: TS.ADD", () => {
+  it(`add to existing key with all options, info shouldn't change`, async () => {
+    expect(await Timeseries.tscreate("temperature:2:32", {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe("OK");
+
+    const now = Date.now();
+    expect(await Timeseries.tsadd("temperature:2:32", now, 1, {
+      retention: 40000,
+      uncompressed: true,
+      labels: {sensor_id: 4, area_id: 42},
+    })).toBe(now);
+    const info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe("2");
+  });
+  it(`add to existing key with no additional options`, async () => {
+    expect(await Timeseries.tscreate("temperature:2:32", {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe("OK");
+
+    const now = Date.now();
+    expect(await Timeseries.tsadd("temperature:2:32", now, 1)).toBe(now);
+  });
+  it(`create new key through add`, async () => {
+    const now = Date.now();
+    expect(await Timeseries.tsadd("temperature:2:32", now, 1, {
+      retention: 60000,
+      uncompressed: true,
+      labels: {sensor_id: 2, area_id: 32},
+    })).toBe(now);
+    const info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe("2");
   });
 });

--- a/test/api/timeseries.spec.ts
+++ b/test/api/timeseries.spec.ts
@@ -22,5 +22,26 @@ afterAll(async () => {
 describe("Redis Timeseries Test: TS.CREATE", () => {
   it(`create key with all options`, async () => {
     expect(await Timeseries.tscreate("temperature:2:32", {retention: 60000, labels: {sensor_id: 2, area_id: 32}})).toBe("OK");
+    const info = await Timeseries.tsinfo("temperature:2:32");
+    expect(info.retentionTime).toBe(60000);
+    expect(info.labels.sensor_id).toBe("2");
+  });
+  it(`create key with no options`, async () => {
+    expect(await Timeseries.tscreate("temperature:3")).toBe("OK");
+    const info = await Timeseries.tsinfo("temperature:3");
+    expect(info.retentionTime).toBe(0);
+    expect(info.labels.sensor_id).toBe(undefined);
+  });
+  it(`create key with only retention option`, async () => {
+    expect(await Timeseries.tscreate("temperature:4", {retention: 1000})).toBe("OK");
+    const info = await Timeseries.tsinfo("temperature:4");
+    expect(info.retentionTime).toBe(1000);
+    expect(info.labels.sensor_id).toBe(undefined);
+  });
+  it(`create key with only label option`, async () => {
+    expect(await Timeseries.tscreate("temperature:5", {labels: {sensor_id: 5}})).toBe("OK");
+    const info = await Timeseries.tsinfo("temperature:5");
+    expect(info.retentionTime).toBe(0);
+    expect(info.labels.sensor_id).toBe("5");
   });
 });

--- a/test/api/timeseries.spec.ts
+++ b/test/api/timeseries.spec.ts
@@ -1,0 +1,26 @@
+import { Tedis, TedisPool } from "../../src/main";
+import { config } from "../../tools/index";
+
+config.port = 6371;
+const Pool = new TedisPool(config);
+let Timeseries: Tedis;
+
+beforeAll(async () => {
+  Timeseries = await Pool.getTedis();
+});
+
+beforeEach(async () => {
+  await Timeseries.command("SELECT", 6);
+  await Timeseries.command("FLUSHDB");
+});
+
+afterAll(async () => {
+  await Timeseries.command("FLUSHDB");
+  Timeseries.close();
+});
+
+describe("Redis Timeseries Test: TS.CREATE", () => {
+  it(`create key with all options`, async () => {
+    expect(await Timeseries.tscreate("temperature:2:32", {retention: 60000, labels: {sensor_id: 2, area_id: 32}})).toBe("OK");
+  });
+});

--- a/test/core/protocol.spec.ts
+++ b/test/core/protocol.spec.ts
@@ -1,3 +1,4 @@
+import { DESTRUCTION } from "dns";
 import { Protocol } from "../../src/core/protocol";
 
 let protocol: Protocol;
@@ -13,83 +14,276 @@ beforeEach(async () => {
 });
 
 describe("parse", () => {
-  it(`+OK`, () => {
-    protocol.write(Buffer.from(`+OK\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: "OK",
-      },
+  // Tests based on specification https://redis.io/topics/protocol
+  describe("RESP Simple Strings", () => {
+    /**
+     * When Redis replies with a Simple String, a client library should return
+     * to the caller a string composed of the first character after the '+' up
+     * to the end of the string, excluding the final CRLF bytes.
+     */
+    it(`+OK`, () => {
+      protocol.write(Buffer.from(`+OK\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "OK",
+        },
+      });
+    });
+    it(`+Another Simple String`, () => {
+      protocol.write(Buffer.from(`+Another Simple String\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "Another Simple String",
+        },
+      });
     });
   });
-  it(`-Error type`, () => {
-    protocol.write(Buffer.from(`-Error type\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: true,
-        data: "Error type",
-      },
+
+  describe("RESP Errors", () => {
+    /**
+     * ... errors are treated by clients as exceptions, and the string that
+     * composes the Error type is the error message itself.
+     *
+     * The first word after the "-", up to the first space or newline,
+     * represents the kind of error returned.
+     */
+    it(`-Error message`, () => {
+      protocol.write(Buffer.from(`-Error message\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: true,
+          data: "Error message",
+        },
+      });
+    });
+    it(`-ERR unknown command 'foobar'`, () => {
+      protocol.write(Buffer.from(`-ERR unknown command 'foobar'\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: true,
+          data: "ERR unknown command 'foobar'",
+        },
+      });
+    });
+    it(`-WRONGTYPE Operation against a key holding the wrong kind of value`, () => {
+      protocol.write(Buffer.from(`-WRONGTYPE Operation against a key holding the wrong kind of value\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: true,
+          data: "WRONGTYPE Operation against a key holding the wrong kind of value",
+        },
+      });
     });
   });
-  it(`:6`, () => {
-    protocol.write(Buffer.from(`:6\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: 6,
-      },
+
+  describe("RESP Integers", () => {
+    /**
+     * This type is just a CRLF terminated string representing an integer,
+     * prefixed by a ":" byte. For example ":0\r\n", or ":1000\r\n" are integer
+     * replies.
+     *
+     * ... the returned integer is guaranteed to be in the range of a signed 64
+     * bit integer.
+     */
+    it(`:0`, () => {
+      protocol.write(Buffer.from(`:0\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: 0,
+        },
+      });
+    });
+    it(`:1000`, () => {
+      protocol.write(Buffer.from(`:1000\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: 1000,
+        },
+      });
+    });
+    it(`:-1`, () => {
+      protocol.write(Buffer.from(`:-1\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: -1,
+        },
+      });
+    });
+    it(`:-2147483648`, () => {
+      protocol.write(Buffer.from(`:-2147483648\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: -2147483648,
+        },
+      });
+    });
+    it(`:2147483647`, () => {
+      protocol.write(Buffer.from(`:2147483647\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: 2147483647,
+        },
+      });
     });
   });
-  it(`* array`, () => {
-    protocol.write(
-      Buffer.from(`*3\r\n$1\r\n1\r\n$5\r\nhello\r\n$5\r\ntedis\r\n`)
-    );
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: ["1", "hello", "tedis"],
-      },
+
+  describe("RESP Bulk Strings", () => {
+    /**
+     * Bulk Strings are encoded in the following way:
+     *  - A "$" byte followed by the number of bytes composing the string
+     *    (a prefixed length), terminated by CRLF.
+     *  - The actual string data.
+     *  - A final CRLF.
+     *
+     * RESP Bulk Strings can also be used in order to signal non-existence of a
+     * value using a special format that is used to represent a Null value. In
+     * this special format the length is -1, and there is no data ... This is
+     * called a **Null Bulk String**. The client library API should not return
+     * an empty string, but a nil object, when the server replies with a Null
+     * Bulk String. For example a Ruby library should return 'nil' while a C
+     * library should return NULL (or set a special flag in the reply object),
+     * and so forth.
+     */
+    it(`$6 foobar`, () => {
+      protocol.write(Buffer.from(`$6\r\nfoobar\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "foobar",
+        },
+      });
+    });
+    it(`$0`, () => {
+      protocol.write(Buffer.from(`$0\r\n\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: "",
+        },
+      });
+    });
+    it(`$-1`, () => {
+      protocol.write(Buffer.from(`$-1\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: null,
+        },
+      });
+    });
+    it(`$ array`, () => {
+      protocol.write(Buffer.from(`$9\r\nhello\r\nworld!\r\n`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: ["hello", "world!"],
+        },
+      });
+    });
+    it(`$ incomplete`, () => {
+      protocol.write(Buffer.from(`$3\r\nhello`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: false,
+        res: {
+          error: false,
+          data: null,
+        },
+      });
     });
   });
-  it(`$ array`, () => {
-    protocol.write(Buffer.from(`$9\r\nhello\r\nworld!\r\n`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: true,
-      res: {
-        error: false,
-        data: ["hello", "world!"],
-      },
+
+  describe("RESP Arrays", () => {
+    /**
+     * RESP Arrays are sent using the following format:
+     *  - A '*' character as the first byte, followed by the number of elements
+     *    in the array as a decimal number, followed by CRLF.
+     *  - An additional RESP type for every element of the Array.
+     */
+    it(`*0 Empty Array`, () => {
+      protocol.write(
+        Buffer.from(`*0\r\n`)
+      );
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: [],
+        },
+      });
     });
-  });
-  it(`* incomplete`, () => {
-    protocol.write(Buffer.from(`*3\r\n$1\r\nhello`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: false,
-      res: {
-        error: false,
-        data: [],
-      },
+    it(`*2 foo bar`, () => {
+      protocol.write(
+        Buffer.from(`*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n`)
+      );
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: ["foo", "bar"],
+        },
+      });
     });
-  });
-  it(`$ incomplete`, () => {
-    protocol.write(Buffer.from(`$3\r\nhello`));
-    protocol.parse();
-    expect(protocol.data).toEqual({
-      state: false,
-      res: {
-        error: false,
-        data: null,
-      },
+    it(`* array`, () => {
+      protocol.write(
+        Buffer.from(`*3\r\n$1\r\n1\r\n$5\r\nhello\r\n$5\r\ntedis\r\n`)
+      );
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: true,
+        res: {
+          error: false,
+          data: ["1", "hello", "tedis"],
+        },
+      });
+    });
+    it(`* incomplete`, () => {
+      protocol.write(Buffer.from(`*3\r\n$1\r\nhello`));
+      protocol.parse();
+      expect(protocol.data).toEqual({
+        state: false,
+        res: {
+          error: false,
+          data: [],
+        },
+      });
     });
   });
   it(`! type error`, () => {


### PR DESCRIPTION
This is the RedisTimeSeries Module I referenced in the pull request #35.  It's not a full implementation of RedisTimeSeries yet, but I'd like to get your feedback on the best way to extend Tedis with Redis Modules.  Currently, I just sort of placed my module inline with all your base Redis-API.  I'm not sure this is the best way, but just used this to get started and see what it takes to add functionality.  Do you think each Redis-Module API should live in completely separate Tedis-Module repositories or is it fine to just add them alongside the base Redis-API?  There are many Redis-modules currently and I'm sure their will only be more over time.

This pull-request implements:
* TS.CREATE
* TS.ALTER
* TS.ADD
* TS.MADD
* TS.INCRBY
* TS.DECRBY
* TS.GET
* TS.INFO

.. to be implemented: TS.CREATERULE, TS.DELETERULE, TS.RANGE, TS.MRANGE, TS.MGET, TS.QUERYINDEX

Tedis is so easy to extend, thank you for creating such a solid foundation!
